### PR TITLE
Remove coverage info for code we intentionally don't test

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Run tests and save coverage
       # run on PR for status check and on push for coverage
       if: ${{ github.base_ref == 'dev' || github.ref == 'refs/heads/dev' }}
-      run: flutter test --coverage && ./.scripts/lcov.sh && lcov --remove coverage/lcov.info 'lib/models/*' -o coverage/lcov.info
+      run: flutter test --coverage && brew install lcov && lcov --remove coverage/lcov.info 'lib/models/*' -o coverage/lcov.info
 
     - name: Coveralls
       # run on push to dev branch, for the coverage

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install Flutter tool
       uses: subosito/flutter-action@v1
       with:
-        channel: 'stable' # or: 'stable' or 'beta'
+        channel: 'dev' # or: 'stable' or 'beta'
 
     ##############################################
     # get dependencies & generate code

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Run tests and save coverage
       # run on PR for status check and on push for coverage
       if: ${{ github.base_ref == 'dev' || github.ref == 'refs/heads/dev' }}
-      run: flutter test --coverage && brew install lcov && lcov --remove coverage/lcov.info 'lib/models/*' -o coverage/lcov.info
+      run: flutter test --coverage && brew install lcov && lcov --remove coverage/lcov.info 'lib/models/*' 'lib/actions/*' 'lib/enums/*' -o coverage/lcov.info
 
     - name: Coveralls
       # run on push to dev branch, for the coverage

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Run tests and save coverage
       # run on PR for status check and on push for coverage
       if: ${{ github.base_ref == 'dev' || github.ref == 'refs/heads/dev' }}
-      run: flutter test --coverage && lcov --remove coverage/lcov.info 'lib/models/*' -o coverage/lcov.info
+      run: flutter test --coverage && ./.scripts/lcov.sh && lcov --remove coverage/lcov.info 'lib/models/*' -o coverage/lcov.info
 
     - name: Coveralls
       # run on push to dev branch, for the coverage

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,4 +1,4 @@
-name: Github Actions
+name: tests
 
 on:
   pull_request:
@@ -53,7 +53,8 @@ jobs:
     - name: Run tests and save coverage
       # run on PR for status check and on push for coverage
       if: ${{ github.base_ref == 'dev' || github.ref == 'refs/heads/dev' }}
-      run: flutter test --coverage
+      run: flutter test --coverage && lcov --remove coverage/lcov.info 'lib/models/*' -o coverage/lcov.info
+
     - name: Coveralls
       # run on push to dev branch, for the coverage
       if: ${{ github.base_ref == 'dev' || github.ref == 'refs/heads/dev' }}

--- a/.scripts/lcov.sh
+++ b/.scripts/lcov.sh
@@ -1,8 +1,0 @@
-# taken from https://github.com/actions/virtual-environments/issues/560#issuecomment-602543882 
-VERSION="1.14"
-mkdir Iconv
-cd Iconv
-wget "https://github.com/linux-test-project/lcov/releases/download/v1.14/lcov-$VERSION.tar.gz"
-tar -xzf "lcov-$VERSION.tar.gz"
-cd "lcov-$VERSION"
-sudo make install

--- a/.scripts/lcov.sh
+++ b/.scripts/lcov.sh
@@ -1,0 +1,7 @@
+VERSION="1.14"
+mkdir Iconv
+cd Iconv
+wget "https://github.com/linux-test-project/lcov/releases/download/v1.14/lcov-$VERSION.tar.gz"
+tar -xzf "lcov-$VERSION.tar.gz"
+cd "lcov-$VERSION"
+sudo make install

--- a/.scripts/lcov.sh
+++ b/.scripts/lcov.sh
@@ -1,3 +1,4 @@
+# taken from https://github.com/actions/virtual-environments/issues/560#issuecomment-602543882 
 VERSION="1.14"
 mkdir Iconv
 cd Iconv


### PR DESCRIPTION
There is no point testing our models as they are just data classes and don't contain any logic.  So I've added a step to the CI to remove the coverage info relating to models.  

It's not clear to me what to do about actions and enums - currently they don't have any logic that I'm aware of, so it makes sense to exclude them from coverage.  I think it makes for a cleaner design if we consider the actions and enums to be data classes as well so I've also excluded them.  I'll add a note to our style guide about models, enums and actions all being data classes. Hopefully we'll get language level support for data classes soon and can enforce it. 