### PR TITLE
Rename ServicesBundle to ReduxBundle

### DIFF
--- a/lib/utils/redux/redux_bundle.dart
+++ b/lib/utils/redux/redux_bundle.dart
@@ -17,7 +17,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:redux/redux.dart';
 
 /// Services can be injected, or if missing are given default values
-class ServicesBundle {
+class ReduxBundle {
   static var _bucketName = 'gs://crowdleague-profile-pics';
   static var _extraMiddlewares = <Middleware>[];
   static var _storeOperations = <StoreOperation>[];
@@ -41,7 +41,7 @@ class ServicesBundle {
   final StorageService _storageService;
   final DeviceService _deviceService;
 
-  ServicesBundle(
+  ReduxBundle(
       {List<Middleware> extraMiddlewares,
       AuthService authService,
       DatabaseService databaseService,

--- a/lib/utils/redux/store_operation.dart
+++ b/lib/utils/redux/store_operation.dart
@@ -6,8 +6,8 @@ typedef Operation = Future<void> Function(Store<AppState> store);
 /// An object that can be created with an arbitrary function and will run the
 /// function on a given [Store].
 ///
-/// [StoreOperation] objects can be added to the [ServicesBundle] class and will
-/// be used by any [ServicesBundle] object when [createStore()] is called
+/// [StoreOperation] objects can be added to the [ReduxBundle] class and will
+/// be used by any [ReduxBundle] object when [createStore()] is called
 class StoreOperation {
   final Operation _operation;
 

--- a/lib/widgets/app/crowd_league_app.dart
+++ b/lib/widgets/app/crowd_league_app.dart
@@ -9,7 +9,7 @@ import 'package:crowdleague/extensions/extensions.dart';
 import 'package:crowdleague/models/app/app_state.dart';
 import 'package:crowdleague/models/navigation/page_data/page_data.dart';
 import 'package:crowdleague/models/settings/settings.dart';
-import 'package:crowdleague/utils/redux/services_bundle.dart';
+import 'package:crowdleague/utils/redux/redux_bundle.dart';
 import 'package:crowdleague/utils/wrappers/firebase_wrapper.dart';
 import 'package:crowdleague/widgets/app/initializing_error_page.dart';
 import 'package:crowdleague/widgets/app/initializing_indicator.dart';
@@ -19,9 +19,9 @@ import 'package:redux/redux.dart';
 
 class CrowdLeagueApp extends StatefulWidget {
   final FirebaseWrapper _firebase;
-  final ServicesBundle _redux;
+  final ReduxBundle _redux;
 
-  CrowdLeagueApp({FirebaseWrapper firebase, ServicesBundle redux})
+  CrowdLeagueApp({FirebaseWrapper firebase, ReduxBundle redux})
       : _firebase = firebase ?? FirebaseWrapper(),
         _redux = redux;
   @override
@@ -29,7 +29,7 @@ class CrowdLeagueApp extends StatefulWidget {
 }
 
 class _CrowdLeagueAppState extends State<CrowdLeagueApp> {
-  ServicesBundle _redux;
+  ReduxBundle _redux;
   Store<AppState> _store;
   dynamic _error;
   bool _initializedFirebase = false;
@@ -45,7 +45,7 @@ class _CrowdLeagueAppState extends State<CrowdLeagueApp> {
       });
 
       // use the injected services bundle if there is one or create one
-      _redux = widget._redux ?? ServicesBundle();
+      _redux = widget._redux ?? ReduxBundle();
       // create the redux store and run any extra operations
       _store = await _redux.createStore();
       setState(() {

--- a/test/mocks/mock_firebase_platform.dart
+++ b/test/mocks/mock_firebase_platform.dart
@@ -6,5 +6,5 @@ import 'package:mockito/mockito.dart';
 ///
 /// The usual method of wrapping [Firebase.instance] and injecting a mock
 /// doesn't work because [Firebase] needs to be setup before the
-/// [ServicesBundle] can be used.
+/// [ReduxBundle] can be used.
 class MockFirebasePlatform extends Mock implements FirebasePlatform {}

--- a/test/utils/services_bundle_mocks.dart
+++ b/test/utils/services_bundle_mocks.dart
@@ -7,7 +7,7 @@ import 'package:crowdleague/services/database_service.dart';
 import 'package:crowdleague/services/device_service.dart';
 import 'package:crowdleague/services/notifications_service.dart';
 import 'package:crowdleague/services/storage_service.dart';
-import 'package:crowdleague/utils/redux/services_bundle.dart';
+import 'package:crowdleague/utils/redux/redux_bundle.dart';
 import 'package:flutter/src/widgets/framework.dart';
 import 'package:flutter/src/widgets/navigator.dart';
 import 'package:redux/src/store.dart';
@@ -16,10 +16,10 @@ import '../mocks/services/auth_service_mocks.dart';
 import '../mocks/services/database_service_mocks.dart';
 import '../mocks/services/storage_service_mocks.dart';
 
-class FakeServicesBundle extends ServicesBundle {
+class FakeReduxBundle extends ReduxBundle {
   final Completer<Store<AppState>> _reduxCompleter;
 
-  FakeServicesBundle(
+  FakeReduxBundle(
       {@required Completer<Store<AppState>> completer,
       GlobalKey<NavigatorState> navKey})
       : _reduxCompleter = completer,

--- a/test/widget/crowd_league_app/crowd_league_app_test.dart
+++ b/test/widget/crowd_league_app/crowd_league_app_test.dart
@@ -35,7 +35,7 @@ void main() {
         (WidgetTester tester) async {
       // create a fake(ish) a services bundle
       final reduxCompleter = Completer<Store<AppState>>();
-      final redux = FakeServicesBundle(completer: reduxCompleter);
+      final redux = FakeReduxBundle(completer: reduxCompleter);
 
       // create a fake firebase wrapper with a supplied completer
       final firebaseCompleter = Completer<FirebaseApp>();
@@ -73,7 +73,7 @@ void main() {
         (WidgetTester tester) async {
       // create a fake(ish) a services bundle
       final reduxCompleter = Completer<Store<AppState>>();
-      final redux = FakeServicesBundle(completer: reduxCompleter);
+      final redux = FakeReduxBundle(completer: reduxCompleter);
 
       // create a fake firebase wrapper with a supplied completer
       final firebaseCompleter = Completer<FirebaseApp>();
@@ -108,7 +108,7 @@ void main() {
         (WidgetTester tester) async {
       // Create a fake(ish) services bundle.
       final reduxCompleter = Completer<Store<AppState>>();
-      final redux = FakeServicesBundle(completer: reduxCompleter);
+      final redux = FakeReduxBundle(completer: reduxCompleter);
 
       // Create a fake firebase wrapper with a supplied completer.
       final firebaseCompleter = Completer<FirebaseApp>();
@@ -158,7 +158,7 @@ void main() {
         (WidgetTester tester) async {
       // Create a fake(ish) services bundle.
       final reduxCompleter = Completer<Store<AppState>>();
-      final redux = FakeServicesBundle(completer: reduxCompleter);
+      final redux = FakeReduxBundle(completer: reduxCompleter);
 
       // Create a fake firebase wrapper with a supplied completer.
       final firebaseCompleter = Completer<FirebaseApp>();
@@ -216,7 +216,7 @@ void main() {
         (WidgetTester tester) async {
       // Create a fake(ish) services bundle.
       final reduxCompleter = Completer<Store<AppState>>();
-      final redux = FakeServicesBundle(completer: reduxCompleter);
+      final redux = FakeReduxBundle(completer: reduxCompleter);
 
       // Create a fake firebase wrapper with a supplied completer.
       final firebaseCompleter = Completer<FirebaseApp>();
@@ -274,7 +274,7 @@ void main() {
         (WidgetTester tester) async {
       // Create a fake(ish) services bundle.
       final reduxCompleter = Completer<Store<AppState>>();
-      final redux = FakeServicesBundle(completer: reduxCompleter);
+      final redux = FakeReduxBundle(completer: reduxCompleter);
 
       // Create a fake firebase wrapper with a supplied completer.
       final firebaseCompleter = Completer<FirebaseApp>();
@@ -332,7 +332,7 @@ void main() {
         (WidgetTester tester) async {
       // Create a fake(ish) services bundle.
       final reduxCompleter = Completer<Store<AppState>>();
-      final redux = FakeServicesBundle(completer: reduxCompleter);
+      final redux = FakeReduxBundle(completer: reduxCompleter);
 
       // Create a fake firebase wrapper with a supplied completer.
       final firebaseCompleter = Completer<FirebaseApp>();
@@ -390,7 +390,7 @@ void main() {
         (WidgetTester tester) async {
       // Create a fake(ish) services bundle.
       final reduxCompleter = Completer<Store<AppState>>();
-      final redux = FakeServicesBundle(completer: reduxCompleter);
+      final redux = FakeReduxBundle(completer: reduxCompleter);
 
       // Create a fake firebase wrapper with a supplied completer.
       final firebaseCompleter = Completer<FirebaseApp>();

--- a/test_driver/firebase_emulators.dart
+++ b/test_driver/firebase_emulators.dart
@@ -1,6 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:crowdleague/models/app/app_state.dart';
-import 'package:crowdleague/utils/redux/services_bundle.dart';
+import 'package:crowdleague/utils/redux/redux_bundle.dart';
 import 'package:crowdleague/utils/redux/store_operation.dart';
 import 'package:crowdleague/widgets/app/crowd_league_app.dart';
 import 'package:flutter/material.dart';
@@ -25,7 +25,7 @@ Future<void> main() async {
 
   // Setup the services bundle to use a different bucket and with an extra
   // middleware that sends each action and state to the rdt server for display.
-  ServicesBundle.setup(
+  ReduxBundle.setup(
       bucketName: 'gs://profile-pics-prototyping',
       extraMiddlewares: [_rdtMiddleware],
       storeOperations: [_rdtOperation],

--- a/test_driver/no_driver.dart
+++ b/test_driver/no_driver.dart
@@ -1,6 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:crowdleague/models/app/app_state.dart';
-import 'package:crowdleague/utils/redux/services_bundle.dart';
+import 'package:crowdleague/utils/redux/redux_bundle.dart';
 import 'package:crowdleague/utils/redux/store_operation.dart';
 import 'package:crowdleague/widgets/app/crowd_league_app.dart';
 import 'package:flutter/material.dart';
@@ -25,7 +25,7 @@ Future<void> main() async {
 
   // Setup the services bundle to use a different bucket and with an extra
   // middleware that sends each action and state to the rdt server for display.
-  ServicesBundle.setup(
+  ReduxBundle.setup(
       bucketName: 'gs://profile-pics-prototyping',
       extraMiddlewares: [_rdtMiddleware],
       storeOperations: [_rdtOperation],


### PR DESCRIPTION
Fixes #140

Just a file and class rename, no other changes. 

- there was at some point, both a ServicesBundle and a ReduxBundle
- the redux stuff got absorbed by the ServicesBundle but kept the name
- the purpose of the bundle is probably better captured by naming it ReduxBundle