### PR TITLE
i264: rename "signing in with firebase.." loading text 

### DIFF
--- a/lib/widgets/app/initializing_indicator.dart
+++ b/lib/widgets/app/initializing_indicator.dart
@@ -18,9 +18,9 @@ class InitializingIndicator extends StatelessWidget {
   Widget build(BuildContext context) {
     var message = '';
     if (!firebaseDone) {
-      message = 'Waiting for Firebase...';
+      message = 'Enticing a ghost into the machine...';
     } else if (!reduxDone) {
-      message = 'Waiting for Redux...';
+      message = 'Plumbing the pipes...';
     }
     return Material(
       child: Column(

--- a/lib/widgets/auth/auth_page/auth_page.dart
+++ b/lib/widgets/auth/auth_page/auth_page.dart
@@ -39,11 +39,11 @@ class _AuthPageState extends State<AuthPage> {
                 case AuthStep.signingInWithGoogle:
                   return WaitingIndicator('Contacting Google...');
                 case AuthStep.signingInWithEmail:
-                  return WaitingIndicator('Signing In With Email...');
+                  return WaitingIndicator('Signing In with Email...');
                 case AuthStep.signingUpWithEmail:
-                  return WaitingIndicator('Signing Up With Email...');
+                  return WaitingIndicator('Creating your Account...');
                 case AuthStep.signingInWithFirebase:
-                  return WaitingIndicator('Signing in with Firebase...');
+                  return WaitingIndicator('Signing in with CrowdLeague...');
                 default:
                   return WaitingIndicator('Auth Step was null... huh?');
               }

--- a/test/widget/auth/auth_page_test.dart
+++ b/test/widget/auth/auth_page_test.dart
@@ -143,7 +143,7 @@ void main() {
 
       // check that correct waiting text is shown
       final firebaseWaitingIndicatorText =
-          find.text('Signing in with Firebase...');
+          find.text('Signing in with CrowdLeague...');
       expect(firebaseWaitingIndicatorText, findsOneWidget);
     });
 

--- a/test/widget/crowd_league_app/crowd_league_app_test.dart
+++ b/test/widget/crowd_league_app/crowd_league_app_test.dart
@@ -54,12 +54,12 @@ void main() {
       expect(initializingIndicatorFinder, findsOneWidget);
 
       // verify the expected text is shown, indicating waiting for both
-      expect(find.text('Waiting for Firebase...'), findsOneWidget);
+      expect(find.text('Enticing a ghost into the machine...'), findsOneWidget);
 
       // complete the firebase future and verfiy text has changed as expected
       firebaseCompleter.complete();
       await tester.pump();
-      expect(find.text('Waiting for Redux...'), findsOneWidget);
+      expect(find.text('Plumbing the pipes...'), findsOneWidget);
 
       // complete the redux completer and verify
       reduxCompleter.complete();


### PR DESCRIPTION
fixes #264 

- I also changed the text on app initialization to avoid suspicious words like "redux" and "firebase" (sort of out of scope but maybe not sort of?) 