### PR TITLE
i161: Add Google Maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ app.*.map.json
 # don't add project credentials to version control
 ios/Runner/GoogleService-Info.plist
 android/app/google-services.json
+# don't add maps api keys file to version control
+ios/Flutter/MapsKey.xcconfig
 # Android keystore for release 
 android/app/keystore.jks
 android/app/keystore.config

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,6 +48,7 @@ android {
         ndkVersion "21.3.6528147"
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        manifestPlaceholders = [mapsKey: mapsKeyProperty]
     }
 
     signingConfigs {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -21,6 +21,11 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
+def mapsKeyProperty = localProperties.getProperty('maps.API_KEY')
+if (mapsKeyProperty == null) {
+    throw new GradleException("Google Maps API Key not found. Define API key with maps.API_KEY in the local.properties file.")
+}
+
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -63,5 +63,7 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <meta-data android:name="com.google.android.geo.API_KEY"
+            android:value="${mapsKey}"/>
     </application>
 </manifest>

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,3 @@
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"
+#include "MapsKey.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,2 +1,3 @@
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"
+#include "MapsKey.xcconfig"

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DE3AA26231EE14E3889984C3 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		F691BEDC2571D50C00B42F27 /* MapsKey.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = MapsKey.xcconfig; path = Flutter/MapsKey.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -87,6 +88,7 @@
 			children = (
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
+				F691BEDC2571D50C00B42F27 /* MapsKey.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
 				9740EEB31CF90195004384FC /* Generated.xcconfig */,
 			);

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Flutter
+import GoogleMaps
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
@@ -12,6 +13,8 @@ import Flutter
       UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
     }
     
+    let mapsKey = Bundle.main.infoDictionary?["maps_api_key"] as! String
+    GMSServices.provideAPIKey(mapsKey)
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -63,5 +63,7 @@
 	<string>Used to capture audio to go with the video</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Used to add profile pics, venue pics, etc.</string>
+	<key>maps_api_key</key>
+	<string>$(MAPS_API_KEY)</string>
 </dict>
 </plist>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   firebase_storage:
   image_picker:
   uuid:
+  permission_handler:
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
fixes #161

At this point google maps open and the GoogleMap widget renders well 
Notes:
Add maps.API_KEY= to android/key.properties. for android app
Add MAPS_API_KEY= to ios/Flutter/MapsKey.xcconfig for ios app

Asking for Location permission at the app start is still to be implemented 