### PR TITLE
Add maptivation statement & update standup section

### DIFF
--- a/.contributing/code-of-conduct.md
+++ b/.contributing/code-of-conduct.md
@@ -68,7 +68,7 @@ DO share your progress with the team
 - Get the team up to speed on where you are in your workflow.
 - Identify anything blocking you.
 - Finish with a "maptivation" statement: 
-  - draw us a map of where we're going 
+  - draw us a map of where we're going today
   - get us excited about getting there 
 
 AVOID blocking the flow 

--- a/.contributing/code-of-conduct.md
+++ b/.contributing/code-of-conduct.md
@@ -63,9 +63,21 @@ DO attempt to communicate effectively when creating tasks/issues/etc.
   - try and read what you've written with the mindset of someone who doesn't have all the context that you currently do 
 
 #### Standups
-- goal is to get the team up to speed on where you are in your workflow. And identify anything blocking you.
-- with the goal of preventing discussions that could waste someones time
-  - try to push any discussions to post-standup 
-  - all team members please feel free to transform into stand up police should a discussion that is wasting your time erupt
-    - stand up police have all rights to flag conversations as post-standup items
+
+DO share your progress with the team
+- Get the team up to speed on where you are in your workflow.
+- Identify anything blocking you.
+- Finish with a "maptivation" statement: 
+  - draw us a map of where we're going 
+  - get us excited about getting there 
+
+AVOID blocking the flow 
+- Try to prevent discussions that are not relevant to standup 
+- Push any such discussions to post-standup 
+  
+DO take action to avoid wasted time 
+- Feel free to speak up should a discussion that is wasting your time erupt
+  
+DO respond positively to requests to move conversations to post-standup  
+- If anyone requests that a conversation is moved to post-standup, the response should be freindly and respectful.
 


### PR DESCRIPTION
As discussed in standup, I'm suggesting we use the phrase "maptivation statement" as a way to remember to finish standup with a statement that aims to:
- draw us a map of where we're going today 
- get us excited about getting there 

I also updated the Standups section to bring it in line with the format used in the rest of the document, ie grouped in DO/AVOID/etc. statements (which is inspired by the similar format of Effective Dart).  The only thing that has really changed is the addition of the maptivation statement, everything else is has just been moved around a bit to allow for the Effective Dart style format. 

