### PR TITLE
Add an entry to style guide for markdown lints

### DIFF
--- a/.contributing/style-guide.md
+++ b/.contributing/style-guide.md
@@ -45,6 +45,10 @@ The [style guide for the Flutter repo](https://github.com/flutter/flutter/wiki/S
   - eg. set the reducer to null when creating a mock store in widget tests rather than use the appReducer 
 
 
+# Markdown Style
+
+Markdown should follow the default set of markdown lints defined in [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint).
+
 
 # Contributing 
 
@@ -105,3 +109,4 @@ Whenever possible, do a rename refactor in a separate PR.
 - keep logic to the middleware & reducers
 - converting to other types can be done with extensions 
 - it's important we stick to this as we don't test any of the models, enums or actions (and the corresponding coverage info is not included) 
+


### PR DESCRIPTION
It may be worth noting that the style guide that requires the markdown lints does not actually follow the lints: 

<img width="976" alt="Screen Shot 2020-12-14 at 4 09 13 pm" src="https://user-images.githubusercontent.com/1059276/102042824-efee8e00-3e26-11eb-9214-a3c73c1c61da.png">

Mañana! 